### PR TITLE
MR1

### DIFF
--- a/forward_one.py
+++ b/forward_one.py
@@ -130,12 +130,12 @@ def main(filepath, seg_size=16000, parameters='trained_model/PASE+_parameters.ck
     # compute final score
     score = kl_d.mean().cpu().numpy()
 
-    print(f"score: {score}")
+    print(f"score: {score:3.0f}")
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser()
     PARSER.add_argument("-f", "--filepath", type=str,
-                        help="File path to test.")
+                        help="File path to test.", required=True)
     PARSER.add_argument("-s", "--seg_size", type=int, default=16000,
                         help="Size of segment used (in number of samples).")
     PARSER.add_argument("-p", "--pase_plus_parameters", type=str,

--- a/forward_one.py
+++ b/forward_one.py
@@ -15,9 +15,6 @@ from audio_loader.dl_frontends.pytorch.fill_ram import get_dataloader_fixed_size
 from audio_loader.activity_detection.simple_VAD import Simple
 
 
-PASE_FOLDER = join(str(Path.home()), 'git/pase+')
-sys.path.append(PASE_FOLDER)
-from pase.models.frontend import wf_builder
 
 
 CUDA0 = torch.device('cuda:0')
@@ -26,7 +23,11 @@ SCORES = ["std_score", "mean_score", "median_score", "min_score", "max_score"]
 
 
 # Load model
-def load_pase_plus(pase_folder=PASE_FOLDER, parameters='trained_model/PASE+_parameters.ckpt'):
+def load_pase_plus(PASE_FOLDER, parameters='trained_model/PASE+_parameters.ckpt'):
+
+    sys.path.append(PASE_FOLDER)
+    from pase.models.frontend import wf_builder
+    
     pase = wf_builder(join(PASE_FOLDER, 'cfg/frontend/PASE+.cfg'))
     pase.eval()
     pase.load_pretrained(parameters, load_last=True, verbose=True)
@@ -103,12 +104,15 @@ def compute_pase_score(model, filepath, featureProcess, sampler, device="cpu"):
         return KL_d
 
 
-def main(filepath, seg_size=16000, parameters='trained_model/PASE+_parameters.ckpt'):
+def main(filepath, pasePath, seg_size=16000, parameters='trained_model/PASE+_parameters.ckpt' ):
     """
     Parameters
     ----------
-    folder_out: str, optional
-        Folder containing the results of the experiment.
+    filePath: str
+        File in input of experiment
+        
+    pasePath: str
+        Path to the path library
 
     seg_size: int, optional
         Number of samples to take, here for the C2SI corpus 16000 samples correspond to 1s
@@ -118,7 +122,7 @@ def main(filepath, seg_size=16000, parameters='trained_model/PASE+_parameters.ck
 
     """
     # load model
-    pase = load_pase_plus(parameters=parameters)
+    pase = load_pase_plus(pasePath, parameters=parameters)
     # load data
     sampler = extract_data(filepath)
 
@@ -136,6 +140,9 @@ if __name__ == '__main__':
     PARSER = argparse.ArgumentParser()
     PARSER.add_argument("-f", "--filepath", type=str,
                         help="File path to test.", required=True)
+    PARSER.add_argument("-l", "--pase_path", type=str,
+                        help="File path to pase library.",
+                        default=join(str(Path.home()), 'git/pase+'))
     PARSER.add_argument("-s", "--seg_size", type=int, default=16000,
                         help="Size of segment used (in number of samples).")
     PARSER.add_argument("-p", "--pase_plus_parameters", type=str,
@@ -143,4 +150,4 @@ if __name__ == '__main__':
                         help="Filepath to the parameters to use.")
     ARGS = PARSER.parse_args()
 
-    main(ARGS.filepath, ARGS.seg_size, ARGS.pase_plus_parameters)
+    main(ARGS.filepath, ARGS.pase_path, ARGS.seg_size, ARGS.pase_plus_parameters)

--- a/forward_one.py
+++ b/forward_one.py
@@ -130,7 +130,7 @@ def main(filepath, seg_size=16000, parameters='trained_model/PASE+_parameters.ck
     # compute final score
     score = kl_d.mean().cpu().numpy()
 
-    print(f"score: {score:3.0f}")
+    print(f"score: {score:1.2e}")
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser()

--- a/pase+_environment.yml
+++ b/pase+_environment.yml
@@ -166,7 +166,6 @@ dependencies:
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.3.7=h0b5b093_0
   - pip:
-    - ahoproc-tools==1.0.0
     - cupy-cuda101==7.1.1
     - fastrlock==0.4
     - gammatone==1.0

--- a/pase+_environment.yml
+++ b/pase+_environment.yml
@@ -177,7 +177,6 @@ dependencies:
     - pynvim==0.4.1
     - pynvrtc==8.0
     - pysptk==0.1.16
-    - pytorch-qrnn==0.2.1
     - sklearn==0.0
     - webrtcvad==2.0.10
 prefix: /home/vincent/.miniconda3/envs/pase+

--- a/pase+_environment.yml
+++ b/pase+_environment.yml
@@ -166,6 +166,9 @@ dependencies:
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.3.7=h0b5b093_0
   - pip:
+    - git+https://github.com/santi-pdp/ahoproc_tools.git
+    - git+https://github.com/detly/gammatone
+    - git+https://github.com/pswietojanski/kaldi-io-for-python.git
     - cupy-cuda101==7.1.1
     - fastrlock==0.4
     - greenlet==0.4.15
@@ -177,7 +180,6 @@ dependencies:
     - pynvim==0.4.1
     - pynvrtc==8.0
     - pysptk==0.1.16
-    - pytorch-qrnn==0.2.1
     - sklearn==0.0
     - webrtcvad==2.0.10
 prefix: /home/vincent/.miniconda3/envs/pase+

--- a/pase+_environment.yml
+++ b/pase+_environment.yml
@@ -168,7 +168,6 @@ dependencies:
   - pip:
     - cupy-cuda101==7.1.1
     - fastrlock==0.4
-    - gammatone==1.0
     - greenlet==0.4.15
     - kaldi-io==0.9.0
     - mock==4.0.1

--- a/pase+_environment.yml
+++ b/pase+_environment.yml
@@ -168,6 +168,7 @@ dependencies:
   - pip:
     - git+https://github.com/santi-pdp/ahoproc_tools.git
     - git+https://github.com/detly/gammatone
+    - git+https://github.com/salesforce/pytorch-qrnn
     - git+https://github.com/pswietojanski/kaldi-io-for-python.git
     - cupy-cuda101==7.1.1
     - fastrlock==0.4


### PR DESCRIPTION
Commit to:

- Add git dependancies in the conda `pase+_environement.yml`
- Force decimal display of score (for later use)
- Makes path to be required in order to use `forwardOne.py`

Note: 

There seems to be a problem with absolute path.
It seems that one (or multiple files) hope for a config file in `~/git/pase+/cfg/frontend`.
It's not problematic in my case (because I can clone pase in the correct directory with docker), but it might be an issue down the line.